### PR TITLE
Add reusable UI components based on mockup design

### DIFF
--- a/frontend/src/components/UI/Field.jsx
+++ b/frontend/src/components/UI/Field.jsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+/**
+ * @param {*} Field is the field component, either input field or third-party
+ */
+const FieldFactory = (Field) => styled(Field)`
+    // Remove default field styling
+    background: none;
+    outline: none;
+    
+    border: 1px;
+    border-color: ${(props) => props.theme.colors.inactive};
+    border-style: solid;
+    border-radius: 5px;
+
+    padding: 0.5rem;
+
+    font-family: Kufam, sans-serif;
+    font-weight: 400;
+    color: #707386;
+    transition: color 0.2s, border-color 0.2s;
+
+    &:hover {
+        color: white;
+    }
+
+    &.field-error {
+        border-color: #8c4c4c;
+    }
+`;
+
+export default FieldFactory;

--- a/frontend/src/components/UI/PrimaryButton.jsx
+++ b/frontend/src/components/UI/PrimaryButton.jsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+const PrimaryButton = styled.button`
+    appearance: none;
+    border: none;
+    outline: none;
+
+    background-color: ${(props) => props.theme.colors.primary};
+    border-radius: 3px;
+    padding: 0rem 3rem;
+
+    font-family: Kufam, sans-serif;
+    font-weight: 400;
+    color: white;
+
+    transition: all .2s ease-in-out;
+
+    &:hover {
+        background-color: #5745a3;
+    }
+
+    &:active {
+        transform: scale(0.9);
+    }
+`;
+
+export default PrimaryButton;

--- a/frontend/src/components/UI/Typography.jsx
+++ b/frontend/src/components/UI/Typography.jsx
@@ -1,0 +1,84 @@
+import styled from 'styled-components';
+
+const P = styled.p`
+    font-family: Kufam, sans-serif;
+    font-weight: 400;
+    color: ${(props) => props.theme.colors.alternateFill};
+
+    margin-block-start: 0em;
+    margin-block-end: 0em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+
+    & > span {
+        display: block;
+    }
+`;
+
+const Label = styled.label`
+    font-family: Kufam, sans-serif;
+    font-weight: 400;
+    font-size: 0.8em;
+    color: ${(props) => props.theme.colors.inactive};
+`;
+
+const H2 = styled.h2`
+    font-family: Kufam, sans-serif;
+    font-weight: 600;
+    font-size: 1.2em;
+    color: ${(props) => props.theme.colors.alternateFill};
+
+    // Give h2 more weight by allowing default margin-block-end
+    margin-block-start: 0em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+
+    & > span {
+        display: block;
+    }
+`;
+
+// Does not work. withComponent erases H2's inherited styles
+/* const H3 = styled(H2)`
+    font-weight: 500;
+`.withComponent('h3'); */
+
+const H3 = styled.h3`
+    font-family: Kufam, sans-serif;
+    font-weight: 400;
+    font-size: 1em;
+    color: ${(props) => props.theme.colors.alternateFill};
+
+    margin-block-start: 0em;
+    margin-block-end: 0em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+
+    & > span {
+        display: block;
+    }
+`;
+
+const H4 = styled.h4`
+    font-family: Kufam, sans-serif;
+    font-weight: 400;
+    color: ${(props) => props.theme.colors.inactive};
+    font-size: 0.8em;
+
+    margin-block-start: 0em;
+    margin-block-end: 0em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+
+    & > span {
+        display: block;
+    }
+`;
+
+export {
+  P,
+  Label,
+  H2,
+  H3,
+  H4,
+};

--- a/frontend/src/components/UI/index.jsx
+++ b/frontend/src/components/UI/index.jsx
@@ -1,0 +1,3 @@
+export { default as FieldFactory } from './Field';
+export { default as PrimaryButton } from './PrimaryButton';
+export * from './Typography';


### PR DESCRIPTION
Behöver feedback! @ITJohan 
Se Typography.jsx. I den filen är idéen att jag ska definiera H3, H4 genom att extenda min H2.
Jag vet att man kan använda 'styled(H2)' vilket jag försökt med, men sedan vill jag att själva HTML taggen ska bli h3 respektive h4.
Finns en styled-components funktion 'withComponent(h3) eller withComponent(h4)', finns ett kommenterat exempel i koden.

Hursomhelst, skriver 'withComponent()' över den style man får från 'styled(H2)', vilket gör den oanvändbar.
Finns det någon sätt att lösa detta?

Har även lagt alla allmänna "reusable" komponenter i en UI mapp om det är ok? Läste en React artikel som rekommenderade det :)