### PR TITLE
Update ESLint config with React plugin, approve console, allow different linebreak styles

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -3,8 +3,10 @@
     "browser": true
   },
   "extends": ["airbnb", "plugin:jest/recommended"],
-  "plugins": ["jest"],
+  "plugins": ["jest", "react"],
   "rules": {
-    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+    "linebreak-style": 0,
+    "no-console": 0
   }
 }


### PR DESCRIPTION
- React plugin, React specifika regler. Tänkte kan vara bra när vi kör React och inte ren JavaScript.
- Tillåter konsol. Är användbart att ha. ESLint har den regeln på plats för att man inte ska printa i produktion, ska vi låta den vara  avaktiverad och skriva vår egen konsol implementation utifrån miljö annars? Exempelvis: Visa endast prints i dev miljö och inte i prod miljö? Annars är det ganska irriterande att debugga utan konsol.
- Tillåta olika linebreak styles. Finns förmodligen i airbnb för att dom inte vill anta att alla använder Git. Men Git självt konverterar alla filer till LF format. Vilket gör denna regel onödig. Linebreak styles är för övrigt jobbig att jobba med då Windows standard är CRLF(antar dom flesta av oss lirar Windows).